### PR TITLE
fix(rest): preserve cause and re-interrupt on Jira REST call failures

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -166,14 +166,13 @@ public class JiraRestService {
 
         try {
             jiraRestClient.getIssueClient().addComment(builder.build(), comment).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException
-                | URISyntaxException
-                | InterruptedException
-                | ExecutionException
-                | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client add comment error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client add comment error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client add comment error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add comment error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | URISyntaxException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client add comment error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add comment error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -181,17 +180,20 @@ public class JiraRestService {
         LOGGER.log(FINE, "[Jira] Fetching issue {0}", issueKey);
         try {
             return jiraRestClient.getIssueClient().getIssue(issueKey).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get issue error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get issue error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
             if (e.getCause() != null
                     && e.getCause() instanceof RestClientException
                     && ((RestClientException) e.getCause()).getStatusCode().isPresent()
                     && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
                 LOGGER.log(INFO, "Issue '" + issueKey + "' not found in Jira.");
-                throw new RestClientException("[Jira] Issue '" + issueKey + "' not found in Jira.", e.getCause());
+                throw new RestClientException("[Jira] Issue '" + issueKey + "' not found in Jira.", e);
             } else {
-                LOGGER.log(WARNING, "Jira REST client get issue error. cause: " + e.getMessage(), e);
-                throw new RestClientException(
-                        "[Jira] Jira REST client get issue error. cause: " + e.getMessage(), e.getCause());
+                LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get issue error. cause: " + e.getMessage());
+                throw new RestClientException("[Jira] Jira REST client get issue error. cause: " + e.getMessage(), e);
             }
         }
     }
@@ -206,10 +208,15 @@ public class JiraRestService {
                                     .spliterator(),
                             false)
                     .collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get issue types error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get issue types error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get issue types error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -232,11 +239,11 @@ public class JiraRestService {
             Thread.currentThread().interrupt();
             LOGGER.log(WARNING, e, () -> "Jira REST client get project issue types error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e);
         } catch (RestClientException | ExecutionException | TimeoutException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client get project issue types error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -250,10 +257,13 @@ public class JiraRestService {
                                     .spliterator(),
                             false)
                     .collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get priorities error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get priorities error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get priorities error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -261,10 +271,15 @@ public class JiraRestService {
         Iterable<BasicProject> projects = Collections.emptyList();
         try {
             projects = jiraRestClient.getProjectClient().getAllProjects().get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get project keys error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get project keys error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get project keys error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get project keys error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get project keys error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get project keys error. cause: " + e.getMessage(), e);
         }
         final List<String> keys = new ArrayList<>();
         for (BasicProject project : projects) {
@@ -285,14 +300,19 @@ public class JiraRestService {
                     .get(timeout, TimeUnit.SECONDS);
             return StreamSupport.stream(searchResult.getIssues().spliterator(), false)
                     .collect(Collectors.toList());
-        } catch (RestClientException
-                | TimeoutException
-                | CancellationException
-                | ExecutionException
-                | InterruptedException e) {
-            LOGGER.log(WARNING, "Jira REST client get issue from jql search error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(
+                    WARNING, e, () -> "[Jira] Jira REST client get issue from jql search error. cause: "
+                            + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get issue from jql search error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get issue from jql search error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | TimeoutException | CancellationException | ExecutionException e) {
+            LOGGER.log(
+                    WARNING, e, () -> "[Jira] Jira REST client get issue from jql search error. cause: "
+                            + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get issue from jql search error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -307,9 +327,8 @@ public class JiraRestService {
 
             decoded = objectMapper.readValue(content.asString(), new TypeReference<List<Map<String, Object>>>() {});
         } catch (URISyntaxException | IOException e) {
-            LOGGER.log(WARNING, "Jira REST client get versions error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client get versions error. cause: " + e.getMessage(), e.getCause());
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get versions error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get versions error. cause: " + e.getMessage(), e);
         }
 
         return decoded.stream()
@@ -341,10 +360,13 @@ public class JiraRestService {
                     .getExtendedVersionRestClient()
                     .createExtendedVersion(versionInput)
                     .get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client add version error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client add version error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client add version error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add version error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client add version error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add version error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -366,14 +388,13 @@ public class JiraRestService {
                     .getExtendedVersionRestClient()
                     .updateExtendedVersion(builder.build(), versionInput)
                     .get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException
-                | URISyntaxException
-                | InterruptedException
-                | ExecutionException
-                | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client release version error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client release version error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client release version error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | URISyntaxException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client release version error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -424,26 +445,33 @@ public class JiraRestService {
 
         try {
             return jiraRestClient.getIssueClient().createIssue(issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST createIssue error: " + e.getMessage(), e);
-            throw new RestClientException("[Jira] Jira REST createIssue error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST createIssue error: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST createIssue error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST createIssue error: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST createIssue error. cause: " + e.getMessage(), e);
         }
     }
 
     public User getUser(String username) {
         try {
             return jiraRestClient.getUserClient().getUser(username).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get user error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get user error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
             if (e.getCause() != null
                     && e.getCause() instanceof RestClientException
                     && ((RestClientException) e.getCause()).getStatusCode().isPresent()
                     && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
                 LOGGER.log(INFO, "User '" + username + "' not found in Jira.");
-                throw new RestClientException("[Jira] User '" + username + "' not found in Jira.", e.getCause());
+                throw new RestClientException("[Jira] User '" + username + "' not found in Jira.", e);
             } else {
-                LOGGER.log(WARNING, "Jira REST client get user error. cause: " + e.getMessage(), e);
-                throw new RestClientException(
-                        "[Jira] Jira REST client get user error. cause: " + e.getMessage(), e.getCause());
+                LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get user error. cause: " + e.getMessage());
+                throw new RestClientException("[Jira] Jira REST client get user error. cause: " + e.getMessage(), e);
             }
         }
     }
@@ -453,10 +481,13 @@ public class JiraRestService {
                 new IssueInputBuilder().setFixVersions(fixVersions).build();
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client update issue error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client update issue error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client update issue error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -466,11 +497,17 @@ public class JiraRestService {
                 .build();
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client update labels error for issue " + issueKey, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client update labels error for issue " + issueKey);
             throw new RestClientException(
                     "[Jira] Jira REST client update labels error for issue: " + issueKey + ". cause: " + e.getMessage(),
-                    e.getCause());
+                    e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client update labels error for issue " + issueKey);
+            throw new RestClientException(
+                    "[Jira] Jira REST client update labels error for issue: " + issueKey + ". cause: " + e.getMessage(),
+                    e);
         }
     }
 
@@ -483,11 +520,17 @@ public class JiraRestService {
 
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client update fields error for issue " + issueKey, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client update fields error for issue " + issueKey);
             throw new RestClientException(
                     "[Jira] Jira REST client update fields error for issue: " + issueKey + ". cause: " + e.getMessage(),
-                    e.getCause());
+                    e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client update fields error for issue " + issueKey);
+            throw new RestClientException(
+                    "[Jira] Jira REST client update fields error for issue: " + issueKey + ". cause: " + e.getMessage(),
+                    e);
         }
     }
 
@@ -498,10 +541,21 @@ public class JiraRestService {
 
         try {
             jiraRestClient.getIssueClient().transition(issue, transitionInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(
+                    WARNING,
+                    e,
+                    () -> "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(
+                    WARNING,
+                    e,
+                    () -> "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
         }
         return issue;
     }
@@ -513,10 +567,17 @@ public class JiraRestService {
             final Iterable<Transition> transitions =
                     jiraRestClient.getIssueClient().getTransitions(issue).get(timeout, TimeUnit.SECONDS);
             return StreamSupport.stream(transitions.spliterator(), false).collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get available actions error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(
+                    WARNING, e, () -> "[Jira] Jira REST client get available actions error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get available actions error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get available actions error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(
+                    WARNING, e, () -> "[Jira] Jira REST client get available actions error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get available actions error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -525,10 +586,13 @@ public class JiraRestService {
             final Iterable<Status> statuses =
                     jiraRestClient.getMetadataClient().getStatuses().get(timeout, TimeUnit.SECONDS);
             return StreamSupport.stream(statuses.spliterator(), false).collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get statuses error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get statuses error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "[Jira] Jira REST client get statuses error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -563,9 +627,12 @@ public class JiraRestService {
 
             return components;
         } catch (URISyntaxException | IOException e) {
-            LOGGER.log(WARNING, "Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+            LOGGER.log(
+                    WARNING,
+                    e,
+                    () -> "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## Summary

Two systemic problems in `JiraRestService` made every Jira failure harder to diagnose and broke job cancellation:

- **Lost cause**: 22 sites threw `new RestClientException(message, e.getCause())` instead of passing `e`. For `TimeoutException`/`InterruptedException`, `getCause()` is typically `null`, so the stack trace and HTTP status code vanished.
- **Swallowed interrupts**: 16 of 17 catch clauses mentioning `InterruptedException` never restored the interrupt flag, so a cancelled build waiting on Jira kept running.

## Changes

- Split every multi-catch that includes `InterruptedException` into its own block that calls `Thread.currentThread().interrupt()`.
- Pass `e`, not `e.getCause()`, as the cause of every new `RestClientException`.
- Switch log calls to the deferred `Supplier` form (`LOGGER.log(WARNING, e, () -> ...)`) instead of eager string concatenation.

